### PR TITLE
Updated ranking to send all data (up to a specified row limit).

### DIFF
--- a/classify_all.sh
+++ b/classify_all.sh
@@ -10,7 +10,7 @@ REST_ENDPOINT=HTTP://localhost:5000
 CLASSIFICATION_FUNCTION=fileUpload
 
 # start classification REST API container
-docker run -d --rm --name classification_rest -p 5000:5000 primitives.azurecr.io/data.world_container:v1.0
+docker run -d --rm --name classification_rest -p 5000:5000 primitives.azurecr.io/simon:1.0.0
 ./wait-for-it.sh -t 0 localhost:5000
 echo "Waiting for the service to be available..."
 sleep 10

--- a/rank_all.sh
+++ b/rank_all.sh
@@ -7,13 +7,14 @@ CLASSIFICATION=/tables/classification.json
 OUTPUT=tables/importance.json
 DATASETS=(26_radon_seed 32_wikiqa 60_jester 185_baseball 196_autoMpg 313_spectrometer 38_sick 4550_MiceProtein)
 TYPE_SOURCE=classification
+ROW_LIMIT=1000
 HAS_HEADER=1
 REST_ENDPOINT=HTTP://localhost:5000
 RANKING_FUNCTION=pca
 NUMERIC_OUTPUT_SUFFIX=_numeric.csv
 DATASET_FOLDER_SUFFIX=_dataset
 
-docker run -d --rm --name ranking_rest  -p 5000:5000 primitives.azurecr.io/http_features:0.2
+docker run -d --rm --name ranking_rest  -p 5000:5000 primitives.azurecr.io/http_features:0.4
 ./wait-for-it.sh -t 0 localhost:5000
 echo "Waiting for the service to be available..."
 sleep 10
@@ -28,9 +29,10 @@ do
         --dataset="$DATA_DIR/${DATASET}/${DATASET}$DATASET_FOLDER_SUFFIX/$MERGED" \
         --rest-endpoint="$REST_ENDPOINT" \
         --ranking-function="$RANKING_FUNCTION" \
-        --numeric-output="$DATA_DIR/${DATASET}/${DATASET}$DATASET_FOLDER_SUFFIX/$DATASET$NUMERIC_OUTPUT_SUFFIX" \
+        --ranking-output="$DATA_DIR/${DATASET}/${DATASET}$DATASET_FOLDER_SUFFIX/$DATASET$NUMERIC_OUTPUT_SUFFIX" \
         --classification="$DATA_DIR/${DATASET}/${DATASET}$DATASET_FOLDER_SUFFIX/$CLASSIFICATION" \
         --has-header=$HAS_HEADER \
+        --row-limit=$ROW_LIMIT \
         --output="$DATA_DIR/${DATASET}/${DATASET}$DATASET_FOLDER_SUFFIX/$OUTPUT" \
         --type-source="$TYPE_SOURCE"
 done


### PR DESCRIPTION
NK updated their ranking & classification images. Ranking can now be done on every column, and the file NEEDS headers. This actually ends up simplifying the ranking step significantly since numeric data no longer has to be extracted.

Note that in the update, NK removed the 1000 rows sampling, so it was added on our end.