### PR TITLE
Variable name split

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -26,7 +26,7 @@ const (
 )
 
 var (
-	nameRegex, _ = regexp.Compile("[^a-zA-Z0-9]")
+	nameRegex = regexp.MustCompile("[^a-zA-Z0-9]")
 )
 
 // Variable represents a single variable description.


### PR DESCRIPTION
Want to have both the original and normalized variable name in ES. Display name is the original name, whereas name is the normalized name.